### PR TITLE
add degree symbol, remove phi symbol

### DIFF
--- a/after/syntax/tex.vim
+++ b/after/syntax/tex.vim
@@ -11,10 +11,12 @@ syn match texMathSymbol '\\rightarrow\>' contained conceal cchar=→
 syn match texMathSymbol '\\leftarrow\>' contained conceal cchar=←
 syn match texMathSymbol '\\emptyset\>' contained conceal cchar=Ø
 syn match texMathSymbol '\\varphi\>' contained conceal cchar=φ
-syn match texMathSymbol '\\phi\>' contained conceal cchar=Φ
 syn match texMathSymbol '\\langle\>\s*' contained conceal cchar=⟨
 syn match texMathSymbol '\s*\\rangle\>' contained conceal cchar=⟩
 syn match texMathSymbol '\\\\' contained conceal cchar=⏎
+
+" gensymb
+syn match texMathSymbol '\\degree\>' contained conceal cchar=°
 
 " logical symbols
 syn match texMathSymbol '\\lor\>' contained conceal cchar=∨


### PR DESCRIPTION
Add degree symbol from `gensymb` package.

Also, remove `phi` symbol because it should be lowercase and default definition is correct.